### PR TITLE
change package type to metapackage.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,5 @@
         "yotpo/module-yotpo-messaging": "4.0.31",
         "yotpo/module-yotpo-reviews": "4.0.31"
     },
-    "type": "magento2-module"
+    "type": "metapackage"
 }


### PR DESCRIPTION
Hi!

Looks like if you join couple packages and it hasn't own classes and functionalities - metapackage looks the proper type for Composer packages and after installation no extra folder in vendor/yotpo after installation. 

Please  review,